### PR TITLE
Track Application lifecycle events

### DIFF
--- a/ios/SegmentAnalytics/Classes/SegmentAnalytics.m
+++ b/ios/SegmentAnalytics/Classes/SegmentAnalytics.m
@@ -14,7 +14,9 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(setup:(NSString*)configKey) {
     SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:configKey];
     configuration.flushAt = 1;
+    configuration.recordScreenViews = YES;
     configuration.shouldUseLocationServices = true;
+    configuration.trackApplicationLifecycleEvents = YES;
     [SEGAnalytics setupWithConfiguration:configuration];
 }
 


### PR DESCRIPTION
The Android version of this library enables these features but the iOS
version doesn't.

This change ensures parity between the 2 platforms.